### PR TITLE
fix small type in example --lang: 1033 -> --lang:1033

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install -g winresourcer
 ```
 
 ```shell
-winresourcer --operation=Update --exeFile=path/to/your/file.exe --resourceType=Icongroup --resourceName:SOME_RESOURCE --lang:1033 --resourceFile:path/to/your/resource.ico
+winresourcer --operation=Update --exeFile=path/to/your/file.exe --resourceType=Icongroup --resourceName:IDR_MAINFRAME --lang:1033 --resourceFile:path/to/your/resource.ico
 ```
 
 ##### Node JS

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install -g winresourcer
 ```
 
 ```shell
-winresourcer --operation=Update --exeFile=path/to/your/file.exe --resourceType=Icongroup --resourceName:SOME_RESOURCE --lang: 1033 --resourceFile:path/to/your/resource.ico
+winresourcer --operation=Update --exeFile=path/to/your/file.exe --resourceType=Icongroup --resourceName:SOME_RESOURCE --lang:1033 --resourceFile:path/to/your/resource.ico
 ```
 
 ##### Node JS


### PR DESCRIPTION
Hey - this is super useful thank you :)

The PR fixes a tiny bug in the example in the Readme where it was complaining about the lang: 1033 because it had a space
